### PR TITLE
Fix for CFG-C-CHANGED warning.

### DIFF
--- a/conf.d/xdebug.ini
+++ b/conf.d/xdebug.ini
@@ -5,4 +5,4 @@ xdebug.mode=develop,debug
 xdebug.client_host=host.docker.internal
 xdebug.start_with_request=yes
 xdebug.idekey=PHPSTORM
-xdebug.remote_port=9000
+xdebug.client_port=9003


### PR DESCRIPTION
In new versions of XDebug the port has been changed from 9000 to 9003 and the "remote_port" config has been renamed as "client_port".